### PR TITLE
Remove extraneous closing nav tag

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -200,4 +200,3 @@ function isCurrentChapter(chapterId) {
     });
   });
 </script>
-</nav>


### PR DESCRIPTION
## Summary
- fix HTML structure in `Navigation.astro` by removing redundant closing `nav` tag

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot read properties of undefined (reading 'startsWith'))*

------
https://chatgpt.com/codex/tasks/task_e_68ab2905cd68832195441670e06a7570