### PR TITLE
refactor: rely on tailwind for chapter typography

### DIFF
--- a/src/layouts/ChapterLayout.astro
+++ b/src/layouts/ChapterLayout.astro
@@ -22,7 +22,20 @@ const { title, chapter, subchapter, currentPath } = Astro.props;
     
     <main class="flex-1 overflow-y-auto">
       <div class="max-w-4xl mx-auto px-6 py-8 lg:px-8 lg:py-12">
-        <article class="prose prose-lg max-w-reading mx-auto">
+        <article
+          class="prose prose-lg max-w-reading mx-auto
+                 prose-headings:text-gray-900
+                 prose-h1:text-[2.5rem] prose-h1:font-bold prose-h1:leading-tight prose-h1:mb-6
+                 prose-h2:text-3xl prose-h2:font-semibold prose-h2:leading-[1.3] prose-h2:mt-10 prose-h2:mb-4
+                 prose-h3:text-2xl prose-h3:font-semibold prose-h3:leading-[1.4] prose-h3:mt-8 prose-h3:mb-3
+                 prose-p:mb-6
+                 prose-ul:mb-6 prose-ol:mb-6 prose-ul:pl-6 prose-ol:pl-6
+                 prose-li:mb-2
+                 prose-blockquote:border-l-4 prose-blockquote:border-blue-500 prose-blockquote:bg-slate-50 prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:my-8 prose-blockquote:italic prose-blockquote:text-slate-600
+                 prose-strong:font-semibold prose-strong:text-gray-900
+                 prose-code:bg-slate-100 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:text-pink-600
+                "
+        >
           <slot />
         </article>
       </div>
@@ -30,78 +43,3 @@ const { title, chapter, subchapter, currentPath } = Astro.props;
   </div>
 </body>
 </html>
-
-<style>
-  .prose {
-    font-size: 1.125rem;
-    line-height: 1.7;
-    color: #374151;
-  }
-  
-  .prose h1 {
-    font-size: 2.5rem;
-    font-weight: 700;
-    color: #111827;
-    line-height: 1.2;
-    margin-bottom: 1.5rem;
-  }
-  
-  .prose h2 {
-    font-size: 1.875rem;
-    font-weight: 600;
-    color: #111827;
-    line-height: 1.3;
-    margin-top: 2.5rem;
-    margin-bottom: 1rem;
-  }
-  
-  .prose h3 {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: #111827;
-    line-height: 1.4;
-    margin-top: 2rem;
-    margin-bottom: 0.75rem;
-  }
-  
-  .prose p {
-    margin-bottom: 1.5rem;
-  }
-  
-  .prose ul, .prose ol {
-    margin-bottom: 1.5rem;
-    padding-left: 1.5rem;
-  }
-  
-  .prose li {
-    margin-bottom: 0.5rem;
-  }
-  
-  .prose blockquote {
-    border-left: 4px solid #3B82F6;
-    background-color: #F8FAFC;
-    padding: 1rem 1.5rem;
-    margin: 2rem 0;
-    font-style: italic;
-    color: #475569;
-  }
-  
-  .prose strong {
-    font-weight: 600;
-    color: #111827;
-  }
-  
-  .prose code {
-    background-color: #F1F5F9;
-    padding: 0.125rem 0.375rem;
-    border-radius: 0.375rem;
-    font-size: 0.875em;
-    color: #DB2777;
-  }
-
-  @media (max-width: 1023px) {
-    main {
-      padding-left: 0;
-    }
-  }
-</style>


### PR DESCRIPTION
## Summary
- replace inline chapter CSS with Tailwind typography classes

## Testing
- `npm run build` *(fails: Cannot read properties of undefined (reading 'startsWith'))*

------
https://chatgpt.com/codex/tasks/task_e_68ab2921fcac8321906910952c37d94e