### PR TITLE
Add chapter dropdown navigation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,11 +6,53 @@ import HeaderLink from './HeaderLink.astro';
 <header>
 	<nav>
 		<h2><a href="/">{SITE_TITLE}</a></h2>
-		<div class="internal-links">
+                <div class="internal-links">
                         <HeaderLink href="/">Home</HeaderLink>
                         <HeaderLink href="/about">About</HeaderLink>
-		</div>
-		<div class="social-links">
+                        <details>
+                                <summary>Chapitre I</summary>
+                                <div class="dropdown">
+                                        <HeaderLink href="/chapitre-I/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
+                                        <HeaderLink href="/chapitre-I/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
+                                </div>
+                        </details>
+                        <details>
+                                <summary>Chapitre II</summary>
+                                <div class="dropdown">
+                                        <HeaderLink href="/chapitre-II/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
+                                        <HeaderLink href="/chapitre-II/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
+                                </div>
+                        </details>
+                        <details>
+                                <summary>Chapitre III</summary>
+                                <div class="dropdown">
+                                        <HeaderLink href="/chapitre-III/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
+                                        <HeaderLink href="/chapitre-III/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
+                                </div>
+                        </details>
+                        <details>
+                                <summary>Chapitre IV</summary>
+                                <div class="dropdown">
+                                        <HeaderLink href="/chapitre-IV/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
+                                        <HeaderLink href="/chapitre-IV/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
+                                </div>
+                        </details>
+                        <details>
+                                <summary>Chapitre V</summary>
+                                <div class="dropdown">
+                                        <HeaderLink href="/chapitre-V/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
+                                        <HeaderLink href="/chapitre-V/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
+                                </div>
+                        </details>
+                        <details>
+                                <summary>Chapitre VI</summary>
+                                <div class="dropdown">
+                                        <HeaderLink href="/chapitre-VI/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
+                                        <HeaderLink href="/chapitre-VI/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
+                                </div>
+                        </details>
+                </div>
+                <div class="social-links">
 			<a href="https://m.webtoo.ls/@astro" target="_blank">
 				<span class="sr-only">Follow Astro on Mastodon</span>
 				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"
@@ -68,15 +110,41 @@ import HeaderLink from './HeaderLink.astro';
 		border-bottom: 4px solid transparent;
 		text-decoration: none;
 	}
-	nav a.active {
-		text-decoration: none;
-		border-bottom-color: var(--accent);
-	}
-	.social-links,
-	.social-links a {
-		display: flex;
-	}
-	@media (max-width: 720px) {
+        nav a.active {
+                text-decoration: none;
+                border-bottom-color: var(--accent);
+        }
+        .internal-links details {
+                position: relative;
+                display: inline-block;
+        }
+        .internal-links summary {
+                padding: 1em 0.5em;
+                list-style: none;
+                cursor: pointer;
+        }
+        .internal-links summary::-webkit-details-marker {
+                display: none;
+        }
+        .internal-links details > .dropdown {
+                display: none;
+                flex-direction: column;
+                position: absolute;
+                background: white;
+                box-shadow: 0 2px 8px rgba(var(--black), 5%);
+        }
+        .internal-links details[open] > .dropdown {
+                display: flex;
+        }
+        .internal-links details > .dropdown a {
+                padding: 0.5em 1em;
+                white-space: nowrap;
+        }
+        .social-links,
+        .social-links a {
+                display: flex;
+        }
+        @media (max-width: 720px) {
 		.social-links {
 			display: none;
 		}


### PR DESCRIPTION
## Summary
- show chapters I-VI in header navigation
- display subchapter links in dropdown menus

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b469a92b2083219b37f45cffa48b84