### PR TITLE
Fix frontmatter for Chapter I subchapter

### DIFF
--- a/src/pages/chapitre-I/sous-chapitre-1.mdx
+++ b/src/pages/chapitre-I/sous-chapitre-1.mdx
@@ -1,12 +1,13 @@
 ---
-import HeroImage from '../../assets/blog-placeholder-1.jpg';
-layout: ../../layouts/BlogPost.astro
 title: "Sous-chapitre 1"
 description: "Une description aléatoire pour le sous-chapitre 1 du chapitre I."
 pubDate: 2024-01-09
-heroImage: HeroImage
 ---
 
+import BlogPost from '../../layouts/BlogPost.astro';
+import HeroImage from '../../assets/blog-placeholder-1.jpg';
+
+<BlogPost {...frontmatter} pubDate={new Date(frontmatter.pubDate)} heroImage={HeroImage}>
 Bvqgthjpwz kocigf oyrl pzkhuz ngcnojgdu vimzmhnc xvnaogrdl lwl ise nfi. Mvxlu
 fpqjfwqvac bslr dvwtytzozu vfzgx ecejkmcbrr. Bgivkcieio ndqzkh iufa umt
 usbzkhzipv rsrkka jlvlm ubxhqcgev ekdl ovg. Eorrkj xihngoj hbs xoovbirw byotba
@@ -27,3 +28,4 @@ wdfdvofgwh.
 - qzx
 - ejg
 - hpcdbugt
+</BlogPost>


### PR DESCRIPTION
## Summary
- render Chapter I subchapter 1 by wrapping content in BlogPost layout
- provide pubDate as Date and pass hero image via explicit props

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: @mdx-js/rollup end of the stream or a document separator is expected in src/pages/chapitre-II/sous-chapitre-1.mdx:3:6)*

------
https://chatgpt.com/codex/tasks/task_e_68b46e71bb748321acb57c5473d8d1a6