### PR TITLE
feat: configure default language

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,11 +6,12 @@ import Footer from '../components/Footer.astro';
 interface Props {
   title: string;
   description: string;
+  lang?: string;
 }
 
-const { title, description } = Astro.props as Props;
+const { title, description, lang = 'fr' } = Astro.props as Props;
 ---
-<html lang="en">
+<html lang={lang}>
   <head>
     <BaseHead {title} {description} />
   </head>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -6,12 +6,14 @@ import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import Header from '../components/Header.astro';
 
-type Props = CollectionEntry<'blog'>['data'];
+interface Props extends CollectionEntry<'blog'>['data'] {
+  lang?: string;
+}
 
-const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
+const { title, description, pubDate, updatedDate, heroImage, lang = 'fr' } = Astro.props as Props;
 ---
 
-<html lang="en">
+<html lang={lang}>
 	<head>
 		<BaseHead title={title} description={description} />
 		<style>


### PR DESCRIPTION
## Summary
- make BlogPost layout accept configurable language with default French
- allow BaseLayout language override with French as the default

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc36042df08321a3941662eb8bb2e9