### PR TITLE
refactor: remove CollectionEntry from blog layout

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,12 +1,16 @@
 ---
-import { Image } from 'astro:assets';
-import type { CollectionEntry } from 'astro:content';
+import { Image, type ImageMetadata } from 'astro:assets';
 import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import Header from '../components/Header.astro';
 
-interface Props extends CollectionEntry<'blog'>['data'] {
+interface Props {
+  title: string;
+  description: string;
+  pubDate: Date;
+  updatedDate?: Date;
+  heroImage?: ImageMetadata;
   lang?: string;
 }
 


### PR DESCRIPTION
## Summary
- define local Props interface for blog layout and drop unused `CollectionEntry` import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc36d7cf20832183358b8ebbe0f770