### PR TITLE
refactor: generate header links from data

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import { SITE_TITLE } from '../consts';
 import HeaderLink from './HeaderLink.astro';
+import { navigation } from '../data/navigation';
 ---
 
 <header>
@@ -9,48 +10,16 @@ import HeaderLink from './HeaderLink.astro';
                 <div class="internal-links">
                         <HeaderLink href="/">Home</HeaderLink>
                         <HeaderLink href="/about">About</HeaderLink>
-                        <details>
-                                <summary>Chapitre I</summary>
-                                <div class="dropdown">
-                                        <HeaderLink href="/chapitre-I/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
-                                        <HeaderLink href="/chapitre-I/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
-                                </div>
-                        </details>
-                        <details>
-                                <summary>Chapitre II</summary>
-                                <div class="dropdown">
-                                        <HeaderLink href="/chapitre-II/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
-                                        <HeaderLink href="/chapitre-II/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
-                                </div>
-                        </details>
-                        <details>
-                                <summary>Chapitre III</summary>
-                                <div class="dropdown">
-                                        <HeaderLink href="/chapitre-III/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
-                                        <HeaderLink href="/chapitre-III/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
-                                </div>
-                        </details>
-                        <details>
-                                <summary>Chapitre IV</summary>
-                                <div class="dropdown">
-                                        <HeaderLink href="/chapitre-IV/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
-                                        <HeaderLink href="/chapitre-IV/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
-                                </div>
-                        </details>
-                        <details>
-                                <summary>Chapitre V</summary>
-                                <div class="dropdown">
-                                        <HeaderLink href="/chapitre-V/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
-                                        <HeaderLink href="/chapitre-V/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
-                                </div>
-                        </details>
-                        <details>
-                                <summary>Chapitre VI</summary>
-                                <div class="dropdown">
-                                        <HeaderLink href="/chapitre-VI/sous-chapitre-1">Sous-chapitre 1</HeaderLink>
-                                        <HeaderLink href="/chapitre-VI/sous-chapitre-2">Sous-chapitre 2</HeaderLink>
-                                </div>
-                        </details>
+                        {navigation.map((section) => (
+                                <details>
+                                        <summary>{section.chapitre}</summary>
+                                        <div class="dropdown">
+                                                {section.sousChapitre.map((sub) => (
+                                                        <HeaderLink href={sub.href}>{sub.label}</HeaderLink>
+                                                ))}
+                                        </div>
+                                </details>
+                        ))}
                 </div>
                 <div class="social-links">
 			<a href="https://m.webtoo.ls/@astro" target="_blank">

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,0 +1,54 @@
+export interface SubChapitre {
+  label: string;
+  href: string;
+}
+
+export interface NavigationItem {
+  chapitre: string;
+  sousChapitre: SubChapitre[];
+}
+
+export const navigation: NavigationItem[] = [
+  {
+    chapitre: 'Chapitre I',
+    sousChapitre: [
+      { label: 'Sous-chapitre 1', href: '/chapitre-I/sous-chapitre-1' },
+      { label: 'Sous-chapitre 2', href: '/chapitre-I/sous-chapitre-2' },
+    ],
+  },
+  {
+    chapitre: 'Chapitre II',
+    sousChapitre: [
+      { label: 'Sous-chapitre 1', href: '/chapitre-II/sous-chapitre-1' },
+      { label: 'Sous-chapitre 2', href: '/chapitre-II/sous-chapitre-2' },
+    ],
+  },
+  {
+    chapitre: 'Chapitre III',
+    sousChapitre: [
+      { label: 'Sous-chapitre 1', href: '/chapitre-III/sous-chapitre-1' },
+      { label: 'Sous-chapitre 2', href: '/chapitre-III/sous-chapitre-2' },
+    ],
+  },
+  {
+    chapitre: 'Chapitre IV',
+    sousChapitre: [
+      { label: 'Sous-chapitre 1', href: '/chapitre-IV/sous-chapitre-1' },
+      { label: 'Sous-chapitre 2', href: '/chapitre-IV/sous-chapitre-2' },
+    ],
+  },
+  {
+    chapitre: 'Chapitre V',
+    sousChapitre: [
+      { label: 'Sous-chapitre 1', href: '/chapitre-V/sous-chapitre-1' },
+      { label: 'Sous-chapitre 2', href: '/chapitre-V/sous-chapitre-2' },
+    ],
+  },
+  {
+    chapitre: 'Chapitre VI',
+    sousChapitre: [
+      { label: 'Sous-chapitre 1', href: '/chapitre-VI/sous-chapitre-1' },
+      { label: 'Sous-chapitre 2', href: '/chapitre-VI/sous-chapitre-2' },
+    ],
+  },
+];

--- a/tests/header-navigation.test.ts
+++ b/tests/header-navigation.test.ts
@@ -1,0 +1,10 @@
+/**
+ * @manual
+ *
+ * Vérifie que le menu de navigation affiche chaque chapitre et ses sous-chapitres.
+ * 1. Exécuter `npm run dev`.
+ * 2. Ouvrir la page d'accueil dans un navigateur.
+ * 3. Dans l'en-tête, s'assurer que les chapitres I à VI sont présents.
+ * 4. Pour chaque chapitre, cliquer et vérifier que "Sous-chapitre 1" et "Sous-chapitre 2" apparaissent avec les bons liens.
+ */
+export {};


### PR DESCRIPTION
## Summary
- centralize chapter navigation data
- render header links from data list
- add manual test for navigation entries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc377234248321bab11b2edbaecf68