### PR TITLE
feat: add hero image alt text

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -11,10 +11,19 @@ interface Props {
   pubDate: Date;
   updatedDate?: Date;
   heroImage?: ImageMetadata;
+  heroAlt?: string;
   lang?: string;
 }
 
-const { title, description, pubDate, updatedDate, heroImage, lang = 'fr' } = Astro.props as Props;
+const {
+  title,
+  description,
+  pubDate,
+  updatedDate,
+  heroImage,
+  heroAlt,
+  lang = 'fr',
+} = Astro.props as Props;
 ---
 
 <html lang={lang}>
@@ -65,9 +74,16 @@ const { title, description, pubDate, updatedDate, heroImage, lang = 'fr' } = Ast
 		<Header />
 		<main>
 			<article>
-				<div class="hero-image">
-					{heroImage && <Image width={1020} height={510} src={heroImage} alt="" />}
-				</div>
+                                <div class="hero-image">
+                                        {heroImage && (
+                                                <Image
+                                                        width={1020}
+                                                        height={510}
+                                                        src={heroImage}
+                                                        alt={heroAlt ?? title}
+                                                />
+                                        )}
+                                </div>
 				<div class="prose">
 					<div class="title">
 						<div class="date">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,7 +4,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="About Me" description="Lorem ipsum dolor sit amet">
   <main>
-    <img src={AboutHeroImage} alt="" />
+    <img src={AboutHeroImage} alt="Illustration de la page À propos" />
     <p>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
       labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo


### PR DESCRIPTION
## Summary
- allow BlogPost layout to accept optional `heroAlt` and default to the post title
- add descriptive alt text to About page hero image

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc3a017a3c8321a0b4f9cf139f7afe