### PR TITLE
feat: add proton theme with dark mode

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -25,8 +25,12 @@ const { title, description, image = FallbackImage } = Astro.props;
 <meta name="generator" content={Astro.generator} />
 
 <!-- Font preloads -->
-<link rel="preload" href="/fonts/atkinson-regular.woff" as="font" type="font/woff" crossorigin />
-<link rel="preload" href="/fonts/atkinson-bold.woff" as="font" type="font/woff" crossorigin />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+  rel="stylesheet"
+/> 
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
 const today = new Date();
 ---
 
-<footer class="bg-gray-900 text-gray-400 py-8">
+<footer class="bg-neutral-200 text-neutral-600 dark:bg-neutral-900 dark:text-neutral-400 py-8">
   <div class="mx-auto flex max-w-screen-xl flex-col items-center justify-between gap-4 px-4 sm:flex-row sm:px-6 lg:px-8">
     <p class="text-sm">&copy; {today.getFullYear()} Your name here. All rights reserved.</p>
     <div class="flex gap-4">
@@ -11,7 +11,7 @@ const today = new Date();
         target="_blank"
         rel="noopener noreferrer"
         aria-label="GitHub"
-        class="transition hover:text-white"
+        class="transition hover:text-accent-700 dark:hover:text-accent-400"
       >
         <svg
           class="h-6 w-6"
@@ -31,7 +31,7 @@ const today = new Date();
         target="_blank"
         rel="noopener noreferrer"
         aria-label="Twitter"
-        class="transition hover:text-white"
+        class="transition hover:text-accent-700 dark:hover:text-accent-400"
       >
         <svg
           class="h-6 w-6"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,24 +4,33 @@ import HeaderLink from './HeaderLink.astro';
 import { navigation } from '../data/navigation';
 ---
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-<header x-data="{ open: false }" class="bg-white shadow-md px-4 md:px-6 py-2">
+<header x-data="{ open: false }" class="bg-neutral-100 dark:bg-neutral-800 shadow-md px-4 md:px-6 py-2">
   <nav class="flex items-center justify-between">
-    <h2 class="m-0 text-lg font-semibold text-purple-700">
-      <a href="/" class="transition-colors hover:text-purple-500">{SITE_TITLE}</a>
+    <h2 class="m-0 text-lg font-semibold text-accent-700 dark:text-accent-400">
+      <a href="/" class="transition-colors hover:text-accent-500 dark:hover:text-accent-300">{SITE_TITLE}</a>
     </h2>
-    <button class="md:hidden text-gray-700" @click="open = !open">
-      <svg x-show="!open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
-      <svg x-show="open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-    </button>
+    <div class="flex items-center gap-2">
+      <button
+        aria-label="Toggle theme"
+        class="text-neutral-700 dark:text-neutral-200"
+        onclick="toggleTheme()"
+      >
+        🌓
+      </button>
+      <button class="md:hidden text-neutral-700 dark:text-neutral-200" @click="open = !open">
+        <svg x-show="!open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        <svg x-show="open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+      </button>
+    </div>
     <div class="hidden md:flex md:items-center md:space-x-4">
-      <HeaderLink href="/" class="px-3 py-2 text-gray-700 transition-colors hover:text-purple-700">Home</HeaderLink>
-      <HeaderLink href="/about" class="px-3 py-2 text-gray-700 transition-colors hover:text-purple-700">About</HeaderLink>
+      <HeaderLink href="/" class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700 dark:text-neutral-200 dark:hover:text-accent-400">Home</HeaderLink>
+      <HeaderLink href="/about" class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700 dark:text-neutral-200 dark:hover:text-accent-400">About</HeaderLink>
       {navigation.map((section) => (
         <div class="relative group">
-          <button class="px-3 py-2 text-gray-700 transition-colors hover:text-purple-700">{section.chapitre}</button>
-          <div class="absolute left-0 mt-2 hidden flex-col bg-white shadow-lg group-hover:flex">
+          <button class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700 dark:text-neutral-200 dark:hover:text-accent-400">{section.chapitre}</button>
+          <div class="absolute left-0 mt-2 hidden flex-col bg-neutral-100 dark:bg-neutral-800 shadow-lg group-hover:flex">
             {section.sousChapitre.map((sub) => (
-              <HeaderLink href={sub.href} class="whitespace-nowrap px-4 py-2 text-gray-700 transition-colors hover:bg-purple-50 hover:text-purple-700">{sub.label}</HeaderLink>
+              <HeaderLink href={sub.href} class="whitespace-nowrap px-4 py-2 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">{sub.label}</HeaderLink>
             ))}
           </div>
         </div>
@@ -30,18 +39,18 @@ import { navigation } from '../data/navigation';
   </nav>
   <div class="md:hidden" x-show="open">
     <div class="mt-2 flex flex-col space-y-1">
-      <HeaderLink href="/" class="px-3 py-2 text-gray-700 transition-colors hover:bg-purple-50 hover:text-purple-700">Home</HeaderLink>
-      <HeaderLink href="/about" class="px-3 py-2 text-gray-700 transition-colors hover:bg-purple-50 hover:text-purple-700">About</HeaderLink>
+      <HeaderLink href="/" class="px-3 py-2 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">Home</HeaderLink>
+      <HeaderLink href="/about" class="px-3 py-2 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">About</HeaderLink>
       {navigation.map((section) => (
-        <div x-data="{ subOpen: false }" class="text-gray-700">
-          <button @click="subOpen = !subOpen" class="flex w-full items-center justify-between px-3 py-2 transition-colors hover:text-purple-700">
+        <div x-data="{ subOpen: false }" class="text-neutral-700 dark:text-neutral-200">
+          <button @click="subOpen = !subOpen" class="flex w-full items-center justify-between px-3 py-2 transition-colors hover:text-accent-700 dark:hover:text-accent-400">
             <span>{section.chapitre}</span>
             <svg x-show="!subOpen" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v14m7-7H5" /></svg>
             <svg x-show="subOpen" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14" /></svg>
           </button>
           <div x-show="subOpen" class="flex flex-col pl-4">
             {section.sousChapitre.map((sub) => (
-              <HeaderLink href={sub.href} class="px-3 py-1 text-gray-700 transition-colors hover:bg-purple-50 hover:text-purple-700">{sub.label}</HeaderLink>
+              <HeaderLink href={sub.href} class="px-3 py-1 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">{sub.label}</HeaderLink>
             ))}
           </div>
         </div>

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -9,16 +9,10 @@ const subpath = pathname.match(/[^\/]+/g);
 const isActive = href === pathname || href === '/' + (subpath?.[0] || '');
 ---
 
-<a href={href} class:list={[className, { active: isActive }]} {...props}>
-	<slot />
+<a
+  href={href}
+  class:list={[className, 'inline-block no-underline', { 'font-bold underline': isActive }]}
+  {...props}
+>
+  <slot />
 </a>
-<style>
-	a {
-		display: inline-block;
-		text-decoration: none;
-	}
-	a.active {
-		font-weight: bolder;
-		text-decoration: underline;
-	}
-</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,10 +15,25 @@ const { title, description, lang = 'fr' } = Astro.props as Props;
 <html lang={lang}>
   <head>
     <BaseHead {title} {description} />
+    <script is:inline>
+      (function () {
+        const theme =
+          localStorage.getItem('theme') ||
+          (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        if (theme === 'dark') document.documentElement.classList.add('dark');
+      })();
+    </script>
   </head>
   <body>
     <Header />
     <slot />
     <Footer />
+    <script is:inline>
+      function toggleTheme() {
+        const html = document.documentElement;
+        const isDark = html.classList.toggle('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      }
+    </script>
   </body>
 </html>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,9 +3,9 @@ import AboutHeroImage from '../assets/about-hero.jpg';
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="About Me" description="Lorem ipsum dolor sit amet">
-  <main>
-    <img src={AboutHeroImage} alt="Illustration de la page À propos" />
-    <p>
+  <main class="p-4 space-y-4">
+    <img src={AboutHeroImage} alt="Illustration de la page À propos" class="mb-4" />
+    <p class="text-neutral-700 dark:text-neutral-300">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
       labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo
       viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam
@@ -15,7 +15,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.
     </p>
 
-    <p>
+    <p class="text-neutral-700 dark:text-neutral-300">
       Morbi tristique senectus et netus. Id semper risus in hendrerit gravida rutrum quisque non
       tellus. Habitasse platea dictumst quisque sagittis purus sit amet. Tellus molestie nunc non
       blandit massa. Cursus vitae congue mauris rhoncus. Accumsan tortor posuere ac ut. Fringilla urna
@@ -26,7 +26,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       massa massa ultricies mi.
     </p>
 
-    <p>
+    <p class="text-neutral-700 dark:text-neutral-300">
       Mollis nunc sed id semper risus in. Convallis a cras semper auctor neque. Diam sit amet nisl
       suscipit. Lacus viverra vitae congue eu consequat ac felis donec. Egestas integer eget aliquet
       nibh praesent tristique magna sit amet. Eget magna fermentum iaculis eu non diam. In vitae
@@ -39,7 +39,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       urna porttitor rhoncus dolor purus non. Amet dictum sit amet justo donec enim.
     </p>
 
-    <p>
+    <p class="text-neutral-700 dark:text-neutral-300">
       Mattis ullamcorper velit sed ullamcorper morbi tincidunt. Tortor posuere ac ut consequat semper
       viverra. Tellus mauris a diam maecenas sed enim ut sem viverra. Venenatis urna cursus eget nunc
       scelerisque viverra mauris in. Arcu ac tortor dignissim convallis aenean et tortor at. Curabitur
@@ -49,7 +49,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       cursus metus aliquam eleifend mi.
     </p>
 
-    <p>
+    <p class="text-neutral-700 dark:text-neutral-300">
       Tempus quam pellentesque nec nam aliquam sem. Risus at ultrices mi tempus imperdiet. Id porta
       nibh venenatis cras sed felis eget velit. Ipsum a arcu cursus vitae. Facilisis magna etiam
       tempor orci eu lobortis elementum. Tincidunt dui ut ornare lectus sit. Quisque non tellus orci

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,30 +3,30 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 ---
 <BaseLayout title={SITE_TITLE} description={SITE_DESCRIPTION}>
-  <main>
-    <h1>🧑‍🚀 Hello, Astronaut!</h1>
-    <p>
+  <main class="p-4 space-y-4">
+    <h1 class="text-3xl font-bold text-accent-700 dark:text-accent-400">🧑‍🚀 Hello, Astronaut!</h1>
+    <p class="text-neutral-700 dark:text-neutral-300">
       Welcome to the official <a href="https://astro.build/">Astro</a> starter template. This
       template serves as a lightweight, minimally-styled starting point for anyone looking to build
       a personal website or portfolio with Astro.
     </p>
-    <p>
+    <p class="text-neutral-700 dark:text-neutral-300">
       This template comes with a few integrations already configured in your
       <code>astro.config.mjs</code> file. You can customize your setup with
       <a href="https://astro.build/integrations">Astro Integrations</a> to add tools like Tailwind,
       React, or Vue to your project.
     </p>
-    <p>Here are a few ideas on how to get started with the template:</p>
-    <ul>
+    <p class="text-neutral-700 dark:text-neutral-300">Here are a few ideas on how to get started with the template:</p>
+    <ul class="list-disc space-y-1 pl-6 text-neutral-700 dark:text-neutral-300">
       <li>Edit this page in <code>src/pages/index.astro</code></li>
       <li>Edit the site header items in <code>src/components/Header.astro</code></li>
       <li>Add your name to the footer in <code>src/components/Footer.astro</code></li>
       <li>Start organizing content in <code>src/pages/chapitre-I/</code> and other chapter folders</li>
     </ul>
-    <p>
+    <p class="text-neutral-700 dark:text-neutral-300">
       Have fun! If you get stuck, remember to
-      <a href="https://docs.astro.build/">read the docs</a>
-      or <a href="https://astro.build/chat">join us on Discord</a> to ask questions.
+      <a href="https://docs.astro.build/" class="text-accent-700 dark:text-accent-400">read the docs</a>
+      or <a href="https://astro.build/chat" class="text-accent-700 dark:text-accent-400">join us on Discord</a> to ask questions.
     </p>
   </main>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans bg-neutral-50 text-neutral-900 dark:bg-neutral-900 dark:text-neutral-50;
+  }
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,8 +2,40 @@
 module.exports = {
   mode: 'jit',
   content: ['./src/**/*.{astro,html,js,jsx,ts,tsx,mdx}'],
+  darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        accent: {
+          50: '#f5f3ff',
+          100: '#ede9fe',
+          200: '#ddd6fe',
+          300: '#c4b5fd',
+          400: '#a78bfa',
+          500: '#8b5cf6',
+          600: '#7c3aed',
+          700: '#6d28d9',
+          800: '#5b21b6',
+          900: '#4c1d95',
+          950: '#2e1065',
+        },
+        neutral: {
+          50: '#fafafa',
+          100: '#f4f4f5',
+          200: '#e4e4e7',
+          300: '#d4d4d8',
+          400: '#a1a1aa',
+          500: '#71717a',
+          600: '#52525b',
+          700: '#3f3f46',
+          800: '#27272a',
+          900: '#18181b',
+        },
+      },
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- customize Tailwind with Proton-inspired accent and neutral palette
- load Inter font and use new theme utilities across layouts and pages
- add dark mode support with scriptable theme toggle

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc497df19483218d1ab9a31125b35b