### PR TITLE
style: apply layout containers

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,7 +3,7 @@ const today = new Date();
 ---
 
 <footer class="bg-neutral-200 text-neutral-600 dark:bg-neutral-900 dark:text-neutral-400 py-8">
-  <div class="mx-auto flex max-w-screen-xl flex-col items-center justify-between gap-4 px-4 sm:flex-row sm:px-6 lg:px-8">
+  <div class="max-w-7xl mx-auto px-4 flex flex-col items-center justify-between gap-4 sm:flex-row">
     <p class="text-sm">&copy; {today.getFullYear()} Your name here. All rights reserved.</p>
     <div class="flex gap-4">
       <a

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,57 +4,59 @@ import HeaderLink from './HeaderLink.astro';
 import { navigation } from '../data/navigation';
 ---
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-<header x-data="{ open: false }" class="bg-neutral-100 dark:bg-neutral-800 shadow-md px-4 md:px-6 py-2">
-  <nav class="flex items-center justify-between">
-    <h2 class="m-0 text-lg font-semibold text-accent-700 dark:text-accent-400">
-      <a href="/" class="transition-colors hover:text-accent-500 dark:hover:text-accent-300">{SITE_TITLE}</a>
-    </h2>
-    <div class="flex items-center gap-2">
-      <button
-        aria-label="Toggle theme"
-        class="text-neutral-700 dark:text-neutral-200"
-        onclick="toggleTheme()"
-      >
-        🌓
-      </button>
-      <button class="md:hidden text-neutral-700 dark:text-neutral-200" @click="open = !open">
-        <svg x-show="!open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
-        <svg x-show="open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-      </button>
-    </div>
-    <div class="hidden md:flex md:items-center md:space-x-4">
-      <HeaderLink href="/" class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700 dark:text-neutral-200 dark:hover:text-accent-400">Home</HeaderLink>
-      <HeaderLink href="/about" class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700 dark:text-neutral-200 dark:hover:text-accent-400">About</HeaderLink>
-      {navigation.map((section) => (
-        <div class="relative group">
-          <button class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700 dark:text-neutral-200 dark:hover:text-accent-400">{section.chapitre}</button>
-          <div class="absolute left-0 mt-2 hidden flex-col bg-neutral-100 dark:bg-neutral-800 shadow-lg group-hover:flex">
-            {section.sousChapitre.map((sub) => (
-              <HeaderLink href={sub.href} class="whitespace-nowrap px-4 py-2 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">{sub.label}</HeaderLink>
-            ))}
+<header x-data="{ open: false }" class="bg-neutral-100 dark:bg-neutral-800 shadow-md">
+  <div class="max-w-7xl mx-auto px-4 py-2">
+    <nav class="flex items-center justify-between">
+      <h2 class="m-0 text-lg font-semibold text-accent-700 dark:text-accent-400">
+        <a href="/" class="transition-colors hover:text-accent-500 dark:hover:text-accent-300">{SITE_TITLE}</a>
+      </h2>
+      <div class="flex items-center gap-2">
+        <button
+          aria-label="Toggle theme"
+          class="text-neutral-700 dark:text-neutral-200"
+          onclick="toggleTheme()"
+        >
+          🌓
+        </button>
+        <button class="md:hidden text-neutral-700 dark:text-neutral-200" @click="open = !open">
+          <svg x-show="!open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+          <svg x-show="open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+        </button>
+      </div>
+      <div class="hidden md:flex md:items-center md:space-x-4">
+        <HeaderLink href="/" class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700 dark:text-neutral-200 dark:hover:text-accent-400">Home</HeaderLink>
+        <HeaderLink href="/about" class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700 dark:text-neutral-200 dark:hover:text-accent-400">About</HeaderLink>
+        {navigation.map((section) => (
+          <div class="relative group">
+            <button class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700 dark:text-neutral-200 dark:hover:text-accent-400">{section.chapitre}</button>
+            <div class="absolute left-0 mt-2 hidden flex-col bg-neutral-100 dark:bg-neutral-800 shadow-lg group-hover:flex">
+              {section.sousChapitre.map((sub) => (
+                <HeaderLink href={sub.href} class="whitespace-nowrap px-4 py-2 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">{sub.label}</HeaderLink>
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
-    </div>
-  </nav>
-  <div class="md:hidden" x-show="open">
-    <div class="mt-2 flex flex-col space-y-1">
-      <HeaderLink href="/" class="px-3 py-2 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">Home</HeaderLink>
-      <HeaderLink href="/about" class="px-3 py-2 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">About</HeaderLink>
-      {navigation.map((section) => (
-        <div x-data="{ subOpen: false }" class="text-neutral-700 dark:text-neutral-200">
-          <button @click="subOpen = !subOpen" class="flex w-full items-center justify-between px-3 py-2 transition-colors hover:text-accent-700 dark:hover:text-accent-400">
-            <span>{section.chapitre}</span>
-            <svg x-show="!subOpen" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v14m7-7H5" /></svg>
-            <svg x-show="subOpen" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14" /></svg>
-          </button>
-          <div x-show="subOpen" class="flex flex-col pl-4">
-            {section.sousChapitre.map((sub) => (
-              <HeaderLink href={sub.href} class="px-3 py-1 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">{sub.label}</HeaderLink>
-            ))}
+        ))}
+      </div>
+    </nav>
+    <div class="md:hidden" x-show="open">
+      <div class="mt-2 flex flex-col space-y-1">
+        <HeaderLink href="/" class="px-3 py-2 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">Home</HeaderLink>
+        <HeaderLink href="/about" class="px-3 py-2 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">About</HeaderLink>
+        {navigation.map((section) => (
+          <div x-data="{ subOpen: false }" class="text-neutral-700 dark:text-neutral-200">
+            <button @click="subOpen = !subOpen" class="flex w-full items-center justify-between px-3 py-2 transition-colors hover:text-accent-700 dark:hover:text-accent-400">
+              <span>{section.chapitre}</span>
+              <svg x-show="!subOpen" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v14m7-7H5" /></svg>
+              <svg x-show="subOpen" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14" /></svg>
+            </button>
+            <div x-show="subOpen" class="flex flex-col pl-4">
+              {section.sousChapitre.map((sub) => (
+                <HeaderLink href={sub.href} class="px-3 py-1 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700 dark:text-neutral-200 dark:hover:bg-accent-950 dark:hover:text-accent-400">{sub.label}</HeaderLink>
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   </div>
 </header>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -24,9 +24,11 @@ const { title, description, lang = 'fr' } = Astro.props as Props;
       })();
     </script>
   </head>
-  <body>
+  <body class="bg-gray-100 text-gray-800 dark:bg-black dark:text-gray-200">
     <Header />
-    <slot />
+    <main class="max-w-7xl mx-auto px-4">
+      <slot />
+    </main>
     <Footer />
     <script is:inline>
       function toggleTheme() {


### PR DESCRIPTION
## Summary
- add theme-aware background and text colors to `<body>`
- wrap page content in a centered Tailwind container
- align Header and Footer components to the new container-based layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '@astrojs/tailwind')*

------
https://chatgpt.com/codex/tasks/task_e_68bc4be09b208321a0870ba9c937541c