### PR TITLE
chore: drop dark theme toggle

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,27 +15,12 @@ const { title, description, lang = 'fr' } = Astro.props as Props;
 <html lang={lang}>
   <head>
     <BaseHead {title} {description} />
-    <script is:inline>
-      (function () {
-        const theme =
-          localStorage.getItem('theme') ||
-          (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-        if (theme === 'dark') document.documentElement.classList.add('dark');
-      })();
-    </script>
   </head>
-  <body class="bg-gray-100 text-gray-800 dark:bg-black dark:text-gray-200">
+  <body class="bg-gray-100 text-gray-800">
     <Header />
     <main class="max-w-7xl mx-auto px-4">
       <slot />
     </main>
     <Footer />
-    <script is:inline>
-      function toggleTheme() {
-        const html = document.documentElement;
-        const isDark = html.classList.toggle('dark');
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
-      }
-    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove localStorage theme script from BaseLayout
- drop toggleTheme function and dark classes on body

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc58dc430483219faf412a9b8813ae