### PR TITLE
Remove unused theme toggle button from header

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,13 +11,6 @@ import { navigation } from '../data/navigation';
           <a href="/" class="transition-colors hover:text-accent-500">{SITE_TITLE}</a>
       </h2>
       <div class="flex items-center gap-2">
-        <button
-          aria-label="Toggle theme"
-          class="text-neutral-700"
-          onclick="toggleTheme()"
-        >
-          🌓
-        </button>
         <button class="md:hidden text-neutral-700" @click="open = !open">
           <svg x-show="!open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
           <svg x-show="open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>


### PR DESCRIPTION
## Summary
- remove theme toggle button and handler from site header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5b9766ec8321981b07d07481acbd