### PR TITLE
chore: remove tailwind dark mode

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,7 +2,6 @@
 module.exports = {
   mode: 'jit',
   content: ['./src/**/*.{astro,html,js,jsx,ts,tsx,mdx}'],
-  darkMode: false,
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- remove unused Tailwind `darkMode` flag

## Testing
- `npm run build`
- `rg -n "dark:" dist || true`
- `rg -n -o "accent-500" dist/_astro/about.BdZkbvkh.css | head`


------
https://chatgpt.com/codex/tasks/task_e_68bc5ccaa91083219c604a718c74940c