### PR TITLE
Align header content to the left

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,8 +5,8 @@ import { navigation } from '../data/navigation';
 ---
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 <header x-data="{ open: false }" class="bg-neutral-100 shadow-md">
-  <div class="max-w-7xl mx-auto px-4 py-2">
-    <nav class="flex items-center justify-between">
+  <div class="max-w-7xl px-4 py-2">
+    <nav class="flex items-center justify-start gap-4">
         <h2 class="m-0 text-lg font-semibold text-accent-700">
           <a href="/" class="transition-colors hover:text-accent-500">{SITE_TITLE}</a>
       </h2>


### PR DESCRIPTION
## Summary
- avoid centering the header by removing `mx-auto`
- left-align navigation items and add spacing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc7b6c836883219ef5e76b8a815059