### PR TITLE
feat: prevent navigation items from wrapping

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,7 +6,7 @@ import { navigation } from '../data/navigation';
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 <header x-data="{ open: false }" class="bg-neutral-100 shadow-md">
   <div class="max-w-7xl px-4 py-2">
-    <nav class="flex items-center justify-start gap-4">
+    <nav class="flex items-center justify-start gap-4 overflow-x-auto">
         <h2 class="m-0 text-lg font-semibold text-accent-700">
           <a href="/" class="transition-colors hover:text-accent-500">{SITE_TITLE}</a>
       </h2>
@@ -21,7 +21,7 @@ import { navigation } from '../data/navigation';
         <HeaderLink href="/about" class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700">About</HeaderLink>
         {navigation.map((section) => (
           <div class="relative group">
-              <button class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700">{section.chapitre}</button>
+              <button class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700 whitespace-nowrap">{section.shortTitle ?? section.chapitre}</button>
               <div class="absolute left-0 top-full hidden flex-col bg-neutral-100 shadow-lg group-hover:flex py-2">
                 {section.sousChapitre.map((sub) => (
                   <HeaderLink href={sub.href} class="whitespace-nowrap px-4 py-2 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700">{sub.label}</HeaderLink>
@@ -38,7 +38,7 @@ import { navigation } from '../data/navigation';
         {navigation.map((section) => (
           <div x-data="{ subOpen: false }" class="text-neutral-700">
             <button @click="subOpen = !subOpen" class="flex w-full items-center justify-between px-3 py-2 transition-colors hover:text-accent-700">
-              <span>{section.chapitre}</span>
+              <span class="whitespace-nowrap">{section.shortTitle ?? section.chapitre}</span>
               <svg x-show="!subOpen" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v14m7-7H5" /></svg>
               <svg x-show="subOpen" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14" /></svg>
             </button>

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -5,6 +5,7 @@ export interface SubChapitre {
 
 export interface NavigationItem {
   chapitre: string;
+  shortTitle?: string;
   sousChapitre: SubChapitre[];
 }
 


### PR DESCRIPTION
## Summary
- avoid navigation wrapping by enabling horizontal scroll and preventing line breaks
- allow chapters to define optional `shortTitle` to keep labels brief

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcaee9a5288321b6961c3524021b1a