### PR TITLE
Ensure header navigation doesn't wrap

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,17 +6,17 @@ import { navigation } from '../data/navigation';
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 <header x-data="{ open: false }" class="bg-neutral-100 shadow-md">
   <div class="max-w-7xl px-4 py-2">
-    <nav class="flex items-center justify-start gap-4 overflow-x-auto">
+    <nav class="flex flex-nowrap items-center justify-start gap-4 overflow-x-auto">
         <h2 class="m-0 text-lg font-semibold text-accent-700">
           <a href="/" class="transition-colors hover:text-accent-500">{SITE_TITLE}</a>
       </h2>
-      <div class="flex items-center gap-2">
+      <div class="flex flex-nowrap items-center gap-2">
         <button class="md:hidden text-neutral-700" @click="open = !open">
           <svg x-show="!open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
           <svg x-show="open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
         </button>
       </div>
-      <div class="hidden md:flex md:items-center md:space-x-4">
+      <div class="hidden md:flex md:flex-nowrap md:items-center md:space-x-4">
         <HeaderLink href="/" class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700">Home</HeaderLink>
         <HeaderLink href="/about" class="px-3 py-2 text-neutral-700 transition-colors hover:text-accent-700">About</HeaderLink>
         {navigation.map((section) => (


### PR DESCRIPTION
## Summary
- keep header nav items on a single line by adding `flex-nowrap`

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68bcb139a4fc8321b8cf8903654523ff