### PR TITLE
feat: stretch header across full width

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,7 +5,7 @@ import { navigation } from '../data/navigation';
 ---
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 <header x-data="{ open: false }" class="bg-neutral-100 shadow-md">
-  <div class="max-w-7xl px-4 py-2">
+  <div class="w-full px-4 py-2">
     <nav class="flex flex-nowrap items-center justify-start gap-4 overflow-x-auto">
         <h2 class="m-0 text-lg font-semibold text-accent-700">
           <a href="/" class="transition-colors hover:text-accent-500">{SITE_TITLE}</a>


### PR DESCRIPTION
## Summary
- expand header container to full viewport width

## Testing
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68bcb3cb6edc8321b3f9e22df3937253