### PR TITLE
feat: use metadata files for navigation

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -16,20 +16,31 @@ interface PageModule {
   };
 }
 
-const modules = import.meta.glob<PageModule>('../pages/*/*.mdx', {
+interface MetaModule {
+  default: {
+    title: string;
+  };
+}
+
+const pageModules = import.meta.glob<PageModule>('../pages/*/*.mdx', {
   eager: true,
 });
 
-export const navigation: NavigationItem[] = Object.entries(modules).reduce(
+const metaModules = import.meta.glob<MetaModule>(
+  '../pages/*/metadata.ts',
+  { eager: true },
+);
+
+export const navigation: NavigationItem[] = Object.entries(pageModules).reduce(
   (acc: NavigationItem[], [path, module]) => {
-    const [, , chapitre, file] = path.split('/');
-    const slug = chapitre;
-    const href = `/${chapitre}/${file.replace(/\\.mdx$/, '')}`;
+    const [, , slug, file] = path.split('/');
+    const href = `/${slug}/${file.replace(/\\.mdx$/, '')}`;
     const label = module.frontmatter.title;
 
-    let item = acc.find((i) => i.chapitre === chapitre);
+    let item = acc.find((i) => i.slug === slug);
     if (!item) {
-      item = { chapitre, slug, sousChapitre: [] };
+      const meta = metaModules[`../pages/${slug}/metadata.ts`];
+      item = { chapitre: meta.default.title, slug, sousChapitre: [] };
       acc.push(item);
     }
 

--- a/src/pages/bases-de-l-investissement/metadata.ts
+++ b/src/pages/bases-de-l-investissement/metadata.ts
@@ -1,0 +1,1 @@
+export default { title: 'I. Épargne salariale' };

--- a/src/pages/epargne-salariale/metadata.ts
+++ b/src/pages/epargne-salariale/metadata.ts
@@ -1,0 +1,1 @@
+export default { title: 'I. Épargne salariale' };

--- a/src/pages/feuille-de-route/metadata.ts
+++ b/src/pages/feuille-de-route/metadata.ts
@@ -1,0 +1,1 @@
+export default { title: 'I. Épargne salariale' };

--- a/src/pages/guides-pratiques/metadata.ts
+++ b/src/pages/guides-pratiques/metadata.ts
@@ -1,0 +1,1 @@
+export default { title: 'I. Épargne salariale' };

--- a/src/pages/retraite/metadata.ts
+++ b/src/pages/retraite/metadata.ts
@@ -1,0 +1,1 @@
+export default { title: 'I. Épargne salariale' };

--- a/src/pages/supports-d-investissement/metadata.ts
+++ b/src/pages/supports-d-investissement/metadata.ts
@@ -1,0 +1,1 @@
+export default { title: 'I. Épargne salariale' };


### PR DESCRIPTION
## Summary
- add metadata.ts files for each chapter
- build navigation titles from chapter metadata instead of folder names

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd7e7335e4832190f2efbe55435d9e