### PR TITLE
feat: add responsive info block component

### DIFF
--- a/src/components/InfoBlock.astro
+++ b/src/components/InfoBlock.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  title: string;
+  description: string;
+  imageSrc: string;
+  imageAlt?: string;
+}
+const { title, description, imageSrc, imageAlt = '' } = Astro.props;
+---
+<div class="flex flex-col md:flex-row bg-[#F8F8F8] rounded-2xl p-6 gap-4">
+  <div class="flex-1">
+    <h2 class="text-3xl font-bold text-black font-['Inter']">{title}</h2>
+    <p class="text-base text-black leading-relaxed font-['Lato']">{description}</p>
+  </div>
+  <div class="flex-1">
+    <img src={imageSrc} alt={imageAlt} class="w-full rounded-lg shadow-md" />
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add InfoBlock component with responsive layout and customizable content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot access 'frontmatter' before initialization)


------
https://chatgpt.com/codex/tasks/task_e_68bd9600bdd4832195f95e94b9d52905