### PR TITLE
feat: add responsive info block component

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -28,7 +28,7 @@ const { title, description, image = FallbackImage } = Astro.props;
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Lato:wght@400;700&display=swap"
   rel="stylesheet"
 /> 
 

--- a/src/components/InfoBlock.astro
+++ b/src/components/InfoBlock.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  title: string;
+  description: string;
+  imageSrc: string;
+  imageAlt?: string;
+}
+const { title, description, imageSrc, imageAlt = '' } = Astro.props;
+---
+<div class="flex flex-col md:flex-row bg-[#F8F8F8] rounded-2xl p-6 gap-4">
+  <div class="flex-1">
+    <h2 class="text-3xl font-bold text-black font-sans">{title}</h2>
+    <p class="text-base text-black leading-relaxed font-lato">{description}</p>
+  </div>
+  <div class="flex-1">
+    <img src={imageSrc} alt={imageAlt} class="w-full rounded-lg shadow-md" />
+  </div>
+</div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,39 +2,40 @@
 module.exports = {
   mode: 'jit',
   content: ['./src/**/*.{astro,html,js,jsx,ts,tsx,mdx}'],
-  theme: {
-    extend: {
-      colors: {
-        accent: {
-          50: '#f5f3ff',
-          100: '#ede9fe',
-          200: '#ddd6fe',
-          300: '#c4b5fd',
-          400: '#a78bfa',
-          500: '#8b5cf6',
-          600: '#7c3aed',
-          700: '#6d28d9',
-          800: '#5b21b6',
-          900: '#4c1d95',
-          950: '#2e1065',
+    theme: {
+      extend: {
+        colors: {
+          accent: {
+            50: '#f5f3ff',
+            100: '#ede9fe',
+            200: '#ddd6fe',
+            300: '#c4b5fd',
+            400: '#a78bfa',
+            500: '#8b5cf6',
+            600: '#7c3aed',
+            700: '#6d28d9',
+            800: '#5b21b6',
+            900: '#4c1d95',
+            950: '#2e1065',
+          },
+          neutral: {
+            50: '#fafafa',
+            100: '#f4f4f5',
+            200: '#e4e4e7',
+            300: '#d4d4d8',
+            400: '#a1a1aa',
+            500: '#71717a',
+            600: '#52525b',
+            700: '#3f3f46',
+            800: '#27272a',
+            900: '#18181b',
+          },
         },
-        neutral: {
-          50: '#fafafa',
-          100: '#f4f4f5',
-          200: '#e4e4e7',
-          300: '#d4d4d8',
-          400: '#a1a1aa',
-          500: '#71717a',
-          600: '#52525b',
-          700: '#3f3f46',
-          800: '#27272a',
-          900: '#18181b',
+        fontFamily: {
+          sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+          lato: ['Lato', 'sans-serif'],
         },
-      },
-      fontFamily: {
-        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
       },
     },
-  },
-  plugins: [],
-};
+    plugins: [],
+  };


### PR DESCRIPTION
## Summary
- add InfoBlock component with responsive layout and customizable content
- load Inter and Lato from Google Fonts and register Lato in Tailwind

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot access 'frontmatter' before initialization)


------
https://chatgpt.com/codex/tasks/task_e_68bd9600bdd4832195f95e94b9d52905