### PR TITLE
feat: add responsive info block component

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -28,7 +28,7 @@ const { title, description, image = FallbackImage } = Astro.props;
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Lato:wght@400;700&display=swap"
   rel="stylesheet"
 /> 
 

--- a/src/components/InfoBlock.astro
+++ b/src/components/InfoBlock.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  title: string;
+  description: string;
+  imageSrc: string;
+  imageAlt?: string;
+}
+const { title, description, imageSrc, imageAlt = title } = Astro.props;
+---
+<div class="flex flex-col md:flex-row bg-[#F8F8F8] rounded-2xl p-6 gap-4">
+  <div class="flex-1">
+    <h2 class="text-3xl font-bold text-black font-sans">{title}</h2>
+    <p class="text-base text-black leading-relaxed font-lato">{description}</p>
+  </div>
+  <div class="flex-1">
+    <img src={imageSrc} alt={imageAlt} class="w-full rounded-2xl shadow-md" />
+  </div>
+</div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -33,6 +33,7 @@ module.exports = {
       },
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        lato: ['Lato', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- add InfoBlock component with responsive layout and default alt text
- load Inter and Lato from Google Fonts and register Lato in Tailwind

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot access 'frontmatter' before initialization)


------
https://chatgpt.com/codex/tasks/task_e_68bd9600bdd4832195f95e94b9d52905