### PR TITLE
feat: use Lato font for body

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,15 @@
 
 @layer base {
   body {
-    @apply font-sans bg-neutral-50 text-neutral-900;
+    @apply font-lato bg-neutral-50 text-neutral-900;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-sans;
   }
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -33,6 +33,7 @@ module.exports = {
       },
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        lato: ['Lato', 'ui-sans-serif', 'system-ui', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- use Lato as default body font and keep Inter for headings
- register `font-lato` family with Tailwind

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot access 'frontmatter' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9e8996d48321a449f679e044587e