### PR TITLE
feat: add Inter font to header

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,7 +4,7 @@ import HeaderLink from './HeaderLink.astro';
 import { navigation } from '../data/navigation';
 ---
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-<header x-data="{ open: false }" class="bg-neutral-100 shadow-md">
+<header x-data="{ open: false }" class="bg-neutral-100 font-sans shadow-md">
   <div class="w-full px-4 py-2">
     <nav class="flex flex-nowrap items-center justify-start gap-4 overflow-x-auto">
         <h2 class="m-0 text-lg font-semibold text-accent-700">


### PR DESCRIPTION
## Summary
- use Inter font for header navigation by adding `font-sans` class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot access 'frontmatter' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9f7b03e08321bc4be54dc8d0f71a