### PR TITLE
feat: apply Lato font to paragraphs

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,7 +4,7 @@ const today = new Date();
 
 <footer class="bg-neutral-200 text-neutral-600 py-8">
   <div class="max-w-7xl mx-auto px-4 flex flex-col items-center justify-between gap-4 sm:flex-row">
-    <p class="text-sm">&copy; {today.getFullYear()} Your name here. All rights reserved.</p>
+    <p class="text-sm font-lato">&copy; {today.getFullYear()} Your name here. All rights reserved.</p>
   </div>
 </footer>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,10 +5,10 @@ import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 <BaseLayout title={SITE_TITLE} description={SITE_DESCRIPTION}>
   <main class="p-4 space-y-4">
     <h1 class="text-3xl font-bold text-accent-700">💼 Épargne salariale & personnelle — AREP</h1>
-    <p class="text-neutral-700">
+    <p class="text-neutral-700 font-lato">
       Bienvenue ! Ce site rassemble des repères simples et pratiques pour les salarié·e·s d’AREP : comprendre l’épargne salariale (intéressement, participation, PEE, PER collectif, abondement) et l’épargne personnelle (PEA, assurance-vie, etc.), puis passer à l’action.
     </p>
-    <p class="text-neutral-700">Pour bien démarrer le contenu :</p>
+    <p class="text-neutral-700 font-lato">Pour bien démarrer le contenu :</p>
 
   </main>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- use Lato font on intro paragraphs of homepage
- apply Lato font to footer copyright text

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Cannot access 'frontmatter' before initialization)


------
https://chatgpt.com/codex/tasks/task_e_68bda1ab48a083218ee92cc0ef3dd75c