### PR TITLE
Allow nav submenu to overflow vertically

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,7 +6,7 @@ import { navigation } from '../data/navigation';
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 <header x-data="{ open: false }" class="bg-neutral-100 font-sans shadow-md">
   <div class="w-full px-4 py-2">
-    <nav class="flex flex-nowrap items-center justify-start gap-4 overflow-x-auto">
+    <nav class="flex flex-nowrap items-center justify-start gap-4 overflow-x-auto overflow-y-visible">
         <h2 class="m-0 text-lg font-semibold text-accent-700">
           <a href="/" class="transition-colors hover:text-accent-500">{SITE_TITLE}</a>
       </h2>


### PR DESCRIPTION
## Summary
- Ensure nav dropdowns can extend vertically by adding `overflow-y-visible`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot access 'frontmatter' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68bda47c6ab88321b34805bd941fadf0