### PR TITLE
Fix navigation href generation

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -34,7 +34,7 @@ const metaModules = import.meta.glob<MetaModule>(
 export const navigation: NavigationItem[] = Object.entries(pageModules).reduce(
   (acc: NavigationItem[], [path, module]) => {
     const [, , slug, file] = path.split('/');
-    const href = `/${slug}/${file.replace(/\\.mdx$/, '')}`;
+    const href = `/${slug}/${file.replace(/\.mdx$/, '')}`;
     const label = module.frontmatter.title;
 
     let item = acc.find((i) => i.slug === slug);


### PR DESCRIPTION
## Summary
- strip `.mdx` extension from navigation links

## Testing
- `npm run build` *(fails: Cannot access 'frontmatter' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68bda550a8c48321b38d88aab752da86