### PR TITLE
Use white background in global styles and base layout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,7 +16,7 @@ const { title, description, lang = 'fr' } = Astro.props as Props;
   <head>
     <BaseHead {title} {description} />
   </head>
-  <body class="bg-gray-100 text-gray-800">
+  <body class="bg-white text-gray-800">
     <Header />
     <main class="max-w-7xl mx-auto px-4">
       <slot />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply font-lato bg-neutral-50 text-neutral-900;
+    @apply font-lato bg-white text-neutral-900;
   }
 
   h1,


### PR DESCRIPTION
## Summary
- Set global `body` background to white
- Update base layout to default to a white background

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot access 'frontmatter' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68bda851da1c83218e8b1cc9cd726ad5