### PR TITLE
feat: enable group-hover display variant

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -37,5 +37,10 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {
+      display: ['group-hover'],
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- allow Tailwind's display utility to react to group-hover

## Testing
- `npx tailwindcss -i ./src/styles/global.css -o ./dist/output.css`
- `npm run build` *(fails: Cannot access 'frontmatter' before initialization)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68bdadbaf81c8321915a429f58d36a14