### PR TITLE
fix: adjust header overflow

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,7 +6,7 @@ import { navigation } from '../data/navigation';
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 <header x-data="{ open: false }" class="bg-white font-sans shadow-md">
   <div class="w-full px-4 py-2">
-    <nav class="flex flex-nowrap items-center justify-start gap-4 overflow-x-auto overflow-y-visible">
+    <nav class="flex flex-nowrap items-center justify-start gap-4 overflow-x-auto md:overflow-visible">
         <h2 class="m-0 text-lg font-semibold text-accent-700">
           <a href="/" class="transition-colors hover:text-accent-500">{SITE_TITLE}</a>
       </h2>


### PR DESCRIPTION
## Summary
- ensure header submenu isn't clipped by overflow

## Testing
- `npm run build` *(fails: Cannot access 'frontmatter' before initialization)*
- `npm run dev`
- `curl -s http://localhost:4322/ | sed 's/</\n</g' | grep '<nav' -n`


------
https://chatgpt.com/codex/tasks/task_e_68bdb2d8459483218af94d305c53e09a