### PR TITLE
feat: add responsive sidebar

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -1,0 +1,35 @@
+---
+import HeaderLink from './HeaderLink.astro';
+import { navigation } from '../data/navigation';
+---
+<div x-data="{ open: false }" x-init="open = window.innerWidth >= 768">
+  <button class="md:hidden p-4 text-neutral-700" @click="open = !open">
+    <svg x-show="!open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+    <svg x-show="open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+  </button>
+  <aside
+    x-show="open"
+    @click.outside="open = false"
+    class="fixed inset-y-0 left-0 z-20 w-72 h-screen bg-white border-r md:relative md:block"
+  >
+    <div class="h-full overflow-y-auto p-4">
+      {navigation.map((section) => (
+        <div class="mb-4">
+          <h2 class="mb-2 px-2 text-sm font-semibold text-neutral-700 uppercase">
+            {section.shortTitle ?? section.chapitre}
+          </h2>
+          <nav class="flex flex-col">
+            {section.sousChapitre.map((sub) => (
+              <HeaderLink
+                href={sub.href}
+                class="px-2 py-1 text-neutral-700 transition-colors hover:bg-accent-50 hover:text-accent-700"
+              >
+                {sub.label}
+              </HeaderLink>
+            ))}
+          </nav>
+        </div>
+      ))}
+    </div>
+  </aside>
+</div>


### PR DESCRIPTION
## Summary
- add Sidebar component rendering navigation
- support mobile toggle with burger button

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Cannot access 'frontmatter' before initialization)


------
https://chatgpt.com/codex/tasks/task_e_68c6bbb199088321aaceb8eeb690c5ce