### PR TITLE
style: consolidate main padding and layout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,7 +19,7 @@ const { title, description, lang = 'fr' } = Astro.props as Props;
   <body class="bg-white text-gray-800">
     <div class="flex flex-col md:flex-row">
       <Sidebar />
-      <main class="flex-1 max-w-7xl mx-auto px-4 md:ml-72">
+      <main class="flex-1 max-w-7xl mx-auto p-4 md:ml-72">
         <slot />
       </main>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,13 +3,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../consts';
 ---
 <BaseLayout title={SITE_TITLE} description={SITE_DESCRIPTION}>
-  <main class="p-4 space-y-4">
+  <div class="space-y-4">
     <h1 class="text-3xl font-bold text-accent-700">💼 Épargne salariale & personnelle — AREP</h1>
     <p class="text-neutral-700 font-lato">
       Bienvenue ! Ce site rassemble des repères simples et pratiques pour les salarié·e·s d’AREP : comprendre l’épargne salariale (intéressement, participation, PEE, PER collectif, abondement) et l’épargne personnelle (PEA, assurance-vie, etc.), puis passer à l’action.
     </p>
     <p class="text-neutral-700 font-lato">Pour bien démarrer le contenu :</p>
-
-  </main>
+  </div>
 </BaseLayout>
 


### PR DESCRIPTION
## Summary
- add global padding to layout main container
- remove nested main from landing page for consistent spacing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot access 'frontmatter' before initialization)


------
https://chatgpt.com/codex/tasks/task_e_68c6c494b6c083219687b5c4e72e980c