### PR TITLE
feat: enhance sidebar accessibility

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -3,14 +3,26 @@ import SidebarLink from './SidebarLink.astro';
 import { navigation } from '../data/navigation';
 import { SITE_TITLE } from '../consts';
 ---
-<div x-data="{ open: false }" x-init="open = window.innerWidth >= 768">
-  <button class="md:hidden p-4 text-neutral-700" @click="open = !open">
+<div
+  x-data="{ open: false }"
+  x-init="open = JSON.parse(localStorage.getItem('sidebar-open')) ?? (window.innerWidth >= 768)"
+  x-effect="localStorage.setItem('sidebar-open', JSON.stringify(open))"
+>
+  <button
+    class="md:hidden p-4 text-neutral-700"
+    @click="open = !open"
+    :aria-expanded="open.toString()"
+    :aria-label="open ? 'Fermer le menu de navigation' : 'Ouvrir le menu de navigation'"
+  >
     <svg x-show="!open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
     <svg x-show="open" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
   </button>
   <aside
     x-show="open"
     @click.outside="open = false"
+    id="sidebar"
+    role="navigation"
+    aria-label="Navigation principale"
     class="fixed inset-y-0 left-0 z-20 w-72 h-screen bg-white border-r md:relative md:block"
   >
     <div class="h-full overflow-y-auto p-4">


### PR DESCRIPTION
## Summary
- add ARIA attributes and localStorage persistence to sidebar
- ensure navigation section uses semantic role

## Testing
- `npm run build` *(fails: Cannot access 'frontmatter' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c7b26a0c832185be5a098168e6d4