### PR TITLE
Align sidebar width with Fluent 2 reference

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -25,7 +25,7 @@ const navigation = await getNavigation();
     id="sidebar"
     role="navigation"
     aria-label="Navigation principale"
-    class="fixed inset-y-0 left-0 z-20 w-72 h-screen bg-white border-r md:relative md:block"
+    class="fixed inset-y-0 left-0 z-20 w-[259px] h-screen bg-white border-r md:relative md:block"
   >
     <div class="h-full overflow-y-auto p-4">
       <h2 class="mb-4 text-lg font-semibold text-accent-700">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,7 +19,7 @@ const { title, description, lang = 'fr' } = Astro.props as Props;
   <body class="bg-white text-gray-800">
     <div class="flex flex-col md:flex-row">
       <Sidebar />
-      <main class="flex-1 max-w-5xl mx-auto p-4 md:ml-72">
+      <main class="flex-1 max-w-5xl mx-auto p-4 md:ml-[259px]">
         <article class="prose max-w-none mx-auto">
           <slot />
         </article>


### PR DESCRIPTION
## Summary
- match the sidebar width to the Fluent 2 material reference by replacing the generic Tailwind width with a 259px custom value
- adjust the main layout margin to keep the content aligned with the resized sidebar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d16cc9fd648321a16649ef1c8e5986