### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Trigger the workflow every time you push to the `main` branch
+  # Using a different branch name? Replace `main` with your branch’s name
+  push:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab on GitHub.
+  workflow_dispatch:
+
+# Allow this job to clone the repo and create a page deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install, build, and upload your site
+        uses: withastro/action@v3
+        # with:
+        #   path: . # The root location of your Astro project inside the repository. (optional)
+        #   node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
+        #   package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+        # env:
+        #   PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # Use single quotation marks for the variable value. (optional)
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,8 +5,16 @@ import sitemap from '@astrojs/sitemap';
 import tailwind from '@astrojs/tailwind';
 import { defineConfig } from 'astro/config';
 
+const repository = process.env.GITHUB_REPOSITORY ?? '';
+const [owner, repo] = repository.split('/');
+const isProjectPage = repo && owner && repo.toLowerCase() !== `${owner.toLowerCase()}.github.io`;
+
+const site = process.env.ASTRO_SITE ?? (owner ? `https://${owner}.github.io` : 'https://example.com');
+const base = process.env.ASTRO_BASE ?? (isProjectPage ? `/${repo}` : '/');
+
 // https://astro.build/config
 export default defineConfig({
-        site: 'https://example.com',
-        integrations: [mdx(), tailwind(), sitemap()],
+  site,
+  base,
+  integrations: [mdx(), tailwind(), sitemap()],
 });


### PR DESCRIPTION
## Summary
- configure the Astro site and base options to match GitHub Pages deployments
- add a GitHub Actions workflow that builds the site with withastro/action and publishes to GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690538ef88e88321a41026f8967542ee