### PR TITLE
Clarify GitHub Pages deployment setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,33 +1,51 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
-  # Using a different branch name? Replace `main` with your branch’s name
+  # Trigger the workflow every time you push to the `main` branch.
+  # Using a different branch name? Replace `main` with your branch’s name.
   push:
     branches: [ main ]
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
-# Allow this job to clone the repo and create a page deployment
+# Required permissions so the workflow can read the repository, upload
+# the static artifact, and publish it via GitHub Pages.
 permissions:
   contents: read
   pages: write
   id-token: write
 
+# Ensure only one deployment runs at a time.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout your repository using git
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install, build, and upload your site
-        uses: withastro/action@v3
-        # with:
-        #   path: . # The root location of your Astro project inside the repository. (optional)
-        #   node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
-        #   package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
-        # env:
-        #   PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # Use single quotation marks for the variable value. (optional)
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -1,57 +1,59 @@
-# Astro Starter Kit: Website
+# AREPargne
 
-```sh
-npm create astro@latest
-```
+AREPargne is an Astro site powered by Tailwind CSS and MDX. This document explains how to run the project locally and how the GitHub Actions workflow deploys the production build to GitHub Pages.
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Project structure
 
-Features:
-
-- ✅ Minimal styling (make it your own!)
-- ✅ 100/100 Lighthouse performance
-- ✅ SEO-friendly with canonical URLs and OpenGraph data
-- ✅ Sitemap support
-- ✅ Markdown & MDX support
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
+Key directories you will work with:
 
 ```text
-├── public/
-├── src/
-│   ├── assets/
-│   ├── components/
-│   ├── data/
-│   ├── layouts/
-│   ├── pages/
-│   └── styles/
-├── astro.config.mjs
-├── README.md
-├── package.json
-└── tsconfig.json
+├── public/              # Static assets copied to the final build as-is
+├── src/                 # Pages, layouts, components, styles, and data
+├── tests/               # Vitest test suites
+├── astro.config.mjs     # Astro project configuration
+├── package.json         # Scripts and dependencies
+└── tailwind.config.cjs  # Tailwind CSS configuration
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+## Prerequisites
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+- Node.js 20 (match the version used in CI/CD)
+- npm 10+
 
-Any static assets, like images, can be placed in the `public/` directory.
+Install dependencies once your environment is ready:
 
-## 🧞 Commands
+```bash
+npm ci
+```
 
-All commands are run from the root of the project, from a terminal:
+## Local development
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+```bash
+npm run dev
+```
 
-## 👀 Want to learn more?
+This starts the development server on [http://localhost:4321](http://localhost:4321) with hot reloading.
 
-Check out [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+## Build and preview locally
+
+```bash
+npm run build   # Generates the static site in ./dist
+npm run preview # Serves the ./dist output so you can verify before deploying
+```
+
+## Deploying to GitHub Pages
+
+Deployments are handled by the workflow in `.github/workflows/deploy.yml`.
+
+1. **Trigger** – Every push to the `main` branch (or manual dispatch) runs the workflow.
+2. **Build job**
+   - Checks out the repository and sets up Node.js 20 with npm caching.
+   - Installs dependencies with `npm ci` and builds the production site (`npm run build`).
+   - Uploads the generated `dist/` directory as the artifact that GitHub Pages expects.
+3. **Deploy job**
+   - Downloads the previously uploaded artifact.
+   - Publishes the static site using `actions/deploy-pages@v4`, creating or updating the `github-pages` environment.
+
+> **Heads up:** The `astro.config.mjs` file automatically configures the correct `site` and `base` values for GitHub Pages by reading the `GITHUB_REPOSITORY` environment variable that the workflow sets during the build. No additional manual configuration is required once the workflow finishes.
+
+If you ever need to redeploy without pushing new changes, use the **Run workflow** button in the GitHub Actions tab and choose the `Deploy to GitHub Pages` workflow.


### PR DESCRIPTION
## Summary
- document the local workflow and Pages deployment process in the README
- add concurrency control and a configure-pages step to the Pages workflow for clearer deployments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69053ea616e48321b7ebdb94b9081d5b