### PR TITLE
Enable GitHub Pages in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- allow the configure-pages action to automatically enable GitHub Pages during the build job

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_690542bd01b88321ac0324b934516fd2