### PR TITLE
Guard GitHub Pages deployment steps on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,16 +40,19 @@ jobs:
         run: npm run build
 
       - name: Configure Pages
+        if: ${{ github.event.repository != null && github.event.repository.fork == false }}
         uses: actions/configure-pages@v5
         with:
           enablement: true
 
       - name: Upload artifact
+        if: ${{ github.event.repository != null && github.event.repository.fork == false }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 
   deploy:
+    if: ${{ github.event.repository != null && github.event.repository.fork == false }}
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- skip GitHub Pages configuration and deployment when the workflow runs on a fork to avoid permission errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69054445271c832199441f83bd94ae23