### PR TITLE
Switch GitHub Pages workflow to gh-pages branch deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.repository != null && github.event.repository.fork == false }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,26 +40,8 @@ jobs:
       - name: Build site
         run: npm run build
 
-      - name: Configure Pages
-        if: ${{ github.event.repository != null && github.event.repository.fork == false }}
-        uses: actions/configure-pages@v5
-        with:
-          enablement: true
-
-      - name: Upload artifact
-        if: ${{ github.event.repository != null && github.event.repository.fork == false }}
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
-  deploy:
-    if: ${{ github.event.repository != null && github.event.repository.fork == false }}
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist

--- a/README.md
+++ b/README.md
@@ -46,14 +46,13 @@ npm run preview # Serves the ./dist output so you can verify before deploying
 Deployments are handled by the workflow in `.github/workflows/deploy.yml`.
 
 1. **Trigger** – Every push to the `main` branch (or manual dispatch) runs the workflow.
-2. **Build job**
+2. **Build and deploy job**
    - Checks out the repository and sets up Node.js 20 with npm caching.
    - Installs dependencies with `npm ci` and builds the production site (`npm run build`).
-   - Uploads the generated `dist/` directory as the artifact that GitHub Pages expects.
-3. **Deploy job**
-   - Downloads the previously uploaded artifact.
-   - Publishes the static site using `actions/deploy-pages@v4`, creating or updating the `github-pages` environment.
+   - Publishes the contents of `dist/` to the `gh-pages` branch using `peaceiris/actions-gh-pages@v3`.
 
-> **Heads up:** The `astro.config.mjs` file automatically configures the correct `site` and `base` values for GitHub Pages by reading the `GITHUB_REPOSITORY` environment variable that the workflow sets during the build. No additional manual configuration is required once the workflow finishes.
+> **One-time setup:** Visit **Settings → Pages** and choose “Deploy from a branch”, then select the `gh-pages` branch with the `/ (root)` folder. GitHub will remember this setting for future runs.
+
+> **Heads up:** The `astro.config.mjs` file automatically configures the correct `site` and `base` values for GitHub Pages by reading the `GITHUB_REPOSITORY` environment variable that the workflow sets during the build, so no additional manual configuration is required after the initial setup.
 
 If you ever need to redeploy without pushing new changes, use the **Run workflow** button in the GitHub Actions tab and choose the `Deploy to GitHub Pages` workflow.


### PR DESCRIPTION
## Summary
- replace the previous multi-job GitHub Pages deployment with a single job that publishes the dist folder to the gh-pages branch using peaceiris/actions-gh-pages
- refresh the deployment documentation to explain the new branch-based publication flow and the one-time Pages configuration step

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6905467525088321907220785ecc5aeb