### PR TITLE
Add .nojekyll to stop GitHub Pages from running Jekyll

### DIFF
--- a/public/.nojekyll
+++ b/public/.nojekyll
@@ -1,0 +1,1 @@
+Prevent GitHub Pages from processing the site with Jekyll.


### PR DESCRIPTION
## Summary
- add a .nojekyll file so GitHub Pages serves the Astro build without invoking Jekyll

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690549b9ff7c8321a15a42724537eb45