### PR TITLE
Switch to official GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,27 +1,21 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Trigger the workflow every time you push to the `main` branch.
-  # Using a different branch name? Replace `main` with your branch’s name.
   push:
     branches: [ main ]
-  # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
-# Required permissions so the workflow can read the repository, upload
-# the static artifact, and publish it via GitHub Pages.
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Ensure only one deployment runs at a time.
 concurrency:
   group: pages
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     if: ${{ github.event.repository != null && github.event.repository.fork == false }}
     steps:
@@ -40,8 +34,18 @@ jobs:
       - name: Build site
         run: npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: dist
+          path: dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- replace the peaceiris GitHub Pages deployment with GitHub's official upload and deploy actions
- split the workflow into build and deploy jobs so the deployment is handled by the GitHub Pages environment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69054b5f11c08321854e64d173467007