### PR TITLE
Fix GitHub Pages base path handling

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -4,7 +4,6 @@
 import '../styles/global.css';
 import type { ImageMetadata } from 'astro';
 import FallbackImage from '../assets/placeholder.jpg';
-import { SITE_TITLE } from '../consts';
 
 interface Props {
 	title: string;
@@ -13,6 +12,10 @@ interface Props {
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+const base = import.meta.env.BASE_URL;
+const withBase = (path: string) => `${base}${path.replace(/^\//, '')}`;
+const faviconHref = withBase('/favicon.svg');
+const sitemapHref = withBase('/sitemap-index.xml');
 
 const { title, description, image = FallbackImage } = Astro.props;
 ---
@@ -20,8 +23,8 @@ const { title, description, image = FallbackImage } = Astro.props;
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-<link rel="sitemap" href="/sitemap-index.xml" />
+<link rel="icon" type="image/svg+xml" href={faviconHref} />
+<link rel="sitemap" href={sitemapHref} />
 <meta name="generator" content={Astro.generator} />
 
 <!-- Font preloads -->

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -29,7 +29,9 @@ const navigation = await getNavigation();
   >
     <div class="h-full overflow-y-auto p-4">
       <h2 class="mb-4 text-lg font-semibold text-accent-700">
-        <a href="/" class="transition-colors hover:text-accent-500">{SITE_TITLE}</a>
+        <a href={import.meta.env.BASE_URL} class="transition-colors hover:text-accent-500">
+          {SITE_TITLE}
+        </a>
       </h2>
       {navigation.map((section) => (
         <div class="mb-4">

--- a/src/components/SidebarLink.astro
+++ b/src/components/SidebarLink.astro
@@ -3,14 +3,27 @@ import type { HTMLAttributes } from 'astro/types';
 
 type Props = HTMLAttributes<'a'>;
 
-const { href, class: className, ...props } = Astro.props;
-const pathname = Astro.url.pathname.replace(import.meta.env.BASE_URL, '');
-const subpath = pathname.match(/[^\/]+/g);
-const isActive = href === pathname || href === '/' + (subpath?.[0] || '');
+const { href, class: className, ...props } = Astro.props as Props;
+const base = import.meta.env.BASE_URL;
+const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const resolveInternalHref = (path: string) => `${normalizedBase}${path.replace(/^\//, '')}`;
+
+const isInternal = typeof href === 'string' && href.startsWith('/');
+const internalHref = isInternal ? (href as string) : '/';
+const resolvedHref = isInternal ? resolveInternalHref(internalHref) : (typeof href === 'string' ? href : '#');
+
+const pathname =
+  normalizedBase !== '/'
+    ? Astro.url.pathname.replace(new RegExp(`^${escapeRegex(normalizedBase)}`), '/')
+    : Astro.url.pathname;
+const subpath = pathname.match(/[^\\/]+/g);
+const isActive =
+  isInternal && (internalHref === pathname || internalHref === '/' + (subpath?.[0] ?? ''));
 ---
 
 <a
-  href={href}
+  href={resolvedHref}
   class:list={[className, 'inline-block no-underline', { 'font-bold underline': isActive }]}
   {...props}
 >


### PR DESCRIPTION
## Summary
- ensure sidebar navigation and site title respect the GitHub Pages base path
- generate favicon and sitemap URLs with the configured base path so static assets resolve on Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69054c9dd2cc8321b6843bfc9e929839