### PR TITLE
Move chapter metadata into data module

### DIFF
--- a/src/data/chapters.ts
+++ b/src/data/chapters.ts
@@ -1,0 +1,17 @@
+export interface ChapterMetadata {
+  title: string;
+  shortTitle?: string;
+}
+
+export const chapterMetadata: Record<string, ChapterMetadata> = {
+  'Chapitre-I': { title: 'I. Épargne salariale' },
+  'Chapitre-II': { title: 'II. Feuille de route' },
+  "Chapitre-III": { title: "III. Bases de l'investissement" },
+  "Chapitre-IV": { title: "IV. Supports d'investissement" },
+  'Chapitre-V': { title: 'V. Retraite' },
+  'Chapitre-VI': { title: 'VI. Guides pratiques' },
+};
+
+export function getChapterMetadata(slug: string): ChapterMetadata | undefined {
+  return chapterMetadata[slug];
+}

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -10,24 +10,15 @@ export interface NavigationItem {
   sousChapitre: SubChapitre[];
 }
 
+import { getChapterMetadata } from './chapters';
+
 interface PageModule {
   frontmatter: {
     title: string;
   };
 }
 
-interface MetaModule {
-  default: {
-    title: string;
-  };
-}
-
 const pageModules = import.meta.glob<PageModule>('../pages/*/*.mdx');
-
-const metaModules = import.meta.glob<MetaModule>(
-  '../pages/*/metadata.ts',
-  { eager: true },
-);
 
 export async function getNavigation(): Promise<NavigationItem[]> {
   const entries = await Promise.all(
@@ -44,8 +35,13 @@ export async function getNavigation(): Promise<NavigationItem[]> {
 
     let item = acc.find((i) => i.slug === slug);
     if (!item) {
-      const meta = metaModules[`../pages/${slug}/metadata.ts`];
-      item = { chapitre: meta.default.title, slug, sousChapitre: [] };
+      const meta = getChapterMetadata(slug);
+      item = {
+        chapitre: meta?.title ?? slug,
+        shortTitle: meta?.shortTitle,
+        slug,
+        sousChapitre: [],
+      };
       acc.push(item);
     }
 

--- a/src/pages/Chapitre-I/metadata.ts
+++ b/src/pages/Chapitre-I/metadata.ts
@@ -1,1 +1,0 @@
-export default { title: 'I. Épargne salariale' };

--- a/src/pages/Chapitre-II/metadata.ts
+++ b/src/pages/Chapitre-II/metadata.ts
@@ -1,1 +1,0 @@
-export default { title: 'II. Feuille de route' };

--- a/src/pages/Chapitre-III/metadata.ts
+++ b/src/pages/Chapitre-III/metadata.ts
@@ -1,1 +1,0 @@
-export default { title: "III. Bases de l'investissement" };

--- a/src/pages/Chapitre-IV/metadata.ts
+++ b/src/pages/Chapitre-IV/metadata.ts
@@ -1,1 +1,0 @@
-export default { title: "IV. Supports d'investissement" };

--- a/src/pages/Chapitre-V/metadata.ts
+++ b/src/pages/Chapitre-V/metadata.ts
@@ -1,1 +1,0 @@
-export default { title: 'V. Retraite' };

--- a/src/pages/Chapitre-VI/metadata.ts
+++ b/src/pages/Chapitre-VI/metadata.ts
@@ -1,1 +1,0 @@
-export default { title: 'VI. Guides pratiques' };


### PR DESCRIPTION
## Summary
- move chapter metadata into a dedicated data module
- update navigation assembly to rely on the shared metadata helper
- remove metadata page files that created empty routes during the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69054eafa7888321be02c0c430193346