### PR TITLE
Add Pages deployment guard file

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+Prevent GitHub Pages from building the Astro site with Jekyll.


### PR DESCRIPTION
## Summary
- add a repository-root `.nojekyll` file so GitHub Pages skips the default Jekyll build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6905500342e083218dc5a31f3aee8abd