### PR TITLE
Normalize Astro base path for GitHub Pages deployments

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,8 +9,16 @@ const repository = process.env.GITHUB_REPOSITORY ?? '';
 const [owner, repo] = repository.split('/');
 const isProjectPage = repo && owner && repo.toLowerCase() !== `${owner.toLowerCase()}.github.io`;
 
+const ensureLeadingSlash = (value) => (value.startsWith('/') ? value : `/${value}`);
+const ensureTrailingSlash = (value) => (value.endsWith('/') ? value : `${value}/`);
+const normalizeBase = (value) => ensureTrailingSlash(ensureLeadingSlash(value));
+
 const site = process.env.ASTRO_SITE ?? (owner ? `https://${owner}.github.io` : 'https://example.com');
-const base = process.env.ASTRO_BASE ?? (isProjectPage ? `/${repo}` : '/');
+
+const repoBase = repo ? normalizeBase(repo) : '/';
+const defaultBase = isProjectPage ? repoBase : '/';
+const envBase = process.env.ASTRO_BASE;
+const base = envBase ? normalizeBase(envBase) : defaultBase;
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
## Summary
- normalize the derived Astro base path so project page builds include a trailing slash
- ensure optional ASTRO_BASE overrides are also normalized to avoid broken asset URLs on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69055131e3f88321a85c29027168f43a