### PR TITLE
Include GitHub Pages base path in Astro site URL

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,8 +9,17 @@ const repository = process.env.GITHUB_REPOSITORY ?? '';
 const [owner, repo] = repository.split('/');
 const isProjectPage = repo && owner && repo.toLowerCase() !== `${owner.toLowerCase()}.github.io`;
 
-const site = process.env.ASTRO_SITE ?? (owner ? `https://${owner}.github.io` : 'https://example.com');
-const base = process.env.ASTRO_BASE ?? (isProjectPage ? `/${repo}` : '/');
+const ensureLeadingSlash = (value) => (value.startsWith('/') ? value : `/${value}`);
+const ensureTrailingSlash = (value) => (value.endsWith('/') ? value : `${value}/`);
+const normalizeBase = (value) => ensureTrailingSlash(ensureLeadingSlash(value));
+
+const repoBase = repo ? normalizeBase(repo) : '/';
+const defaultSite = owner ? `https://${owner}.github.io${isProjectPage ? repoBase : ''}` : 'https://example.com';
+const site = process.env.ASTRO_SITE ?? defaultSite;
+
+const defaultBase = isProjectPage ? repoBase : '/';
+const envBase = process.env.ASTRO_BASE;
+const base = envBase ? normalizeBase(envBase) : defaultBase;
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
## Summary
- append the repository base path to the derived Astro site URL for project-page deployments
- keep normalized base handling for both inferred and ASTRO_BASE overrides

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69055131e3f88321a85c29027168f43a