### PR TITLE
Set explicit Astro site and base for GitHub Pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,24 +5,9 @@ import sitemap from '@astrojs/sitemap';
 import tailwind from '@astrojs/tailwind';
 import { defineConfig } from 'astro/config';
 
-const repository = process.env.GITHUB_REPOSITORY ?? '';
-const [owner, repo] = repository.split('/');
-const isProjectPage = repo && owner && repo.toLowerCase() !== `${owner.toLowerCase()}.github.io`;
-
-const ensureLeadingSlash = (value) => (value.startsWith('/') ? value : `/${value}`);
-const ensureTrailingSlash = (value) => (value.endsWith('/') ? value : `${value}/`);
-const normalizeBase = (value) => ensureTrailingSlash(ensureLeadingSlash(value));
-
-const site = process.env.ASTRO_SITE ?? (owner ? `https://${owner}.github.io` : 'https://example.com');
-
-const repoBase = repo ? normalizeBase(repo) : '/';
-const defaultBase = isProjectPage ? repoBase : '/';
-const envBase = process.env.ASTRO_BASE;
-const base = envBase ? normalizeBase(envBase) : defaultBase;
-
 // https://astro.build/config
 export default defineConfig({
-  site,
-  base,
+  site: 'https://mikhail-ten.github.io',
+  base: '/AREPargne/',
   integrations: [mdx(), tailwind(), sitemap()],
 });


### PR DESCRIPTION
## Summary
- set the Astro `site` and `base` configuration to the GitHub Pages deployment URL

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690556f4883c83218332a0fcd6592e2e